### PR TITLE
Fix Importlib Usage and Document Linux Setup

### DIFF
--- a/worlds/ssbb_sse/SD.py
+++ b/worlds/ssbb_sse/SD.py
@@ -8,6 +8,7 @@ from CommonClient import CommonContext, logger
 import tempfile
 import bsdiff4
 
+SDCARD_ANCHOR = "worlds.ssbb_sse.sdcard"
 
 def create_sd(ctx: CommonContext):
     dolphin_tool = get_settings().sse_settings.dolphin_tool
@@ -46,10 +47,10 @@ def create_sd(ctx: CommonContext):
     # necessary codes
     codes_dir = sd_dir / "codes"
     codes_dir.mkdir()
-    with importlib.resources.open_binary(__name__, "sdcard/RSBE01.gct") as rsbe_bytes:
+    with importlib.resources.open_binary(SDCARD_ANCHOR, "RSBE01.gct") as rsbe_bytes:
         rsbe01_gct = codes_dir / "RSBE01.gct"
         rsbe01_gct.write_bytes(rsbe_bytes.read())
-    with importlib.resources.open_text(__name__, "sdcard/RSBE01.txt") as rsbe_txt:
+    with importlib.resources.open_text(SDCARD_ANCHOR, "RSBE01.txt") as rsbe_txt:
         rsbe01_txt = codes_dir / "RSBE01.txt"
         rsbe01_txt.write_text(rsbe_txt.read())
 
@@ -82,7 +83,7 @@ def create_sd(ctx: CommonContext):
         pac_420037a_o = temp_dir / "DATA/files/stage/adventure/420037a.pac"
         pac_420037a = adventure_pac_folder / "420037a.pac"
 
-        patch_file(pac_420037a_o, "sdcard/420037a.patch", pac_420037a)
+        patch_file(pac_420037a_o, "420037a.patch", pac_420037a)
 
         # Patch title screen
         subprocess.run(
@@ -101,7 +102,7 @@ def create_sd(ctx: CommonContext):
         sc_title_o = temp_dir / "DATA/files/menu2/sc_title_en.pac"
         sc_title = menu2_folder / "sc_title.pac"
 
-        patch_file(sc_title_o, "sdcard/sc_title.patch", sc_title)
+        patch_file(sc_title_o, "sc_title.patch", sc_title)
 
     logger.info("Created SD card directory at " + str(sd_dir))
     logger.info("Please use Dolphin to convert the directory into a usable SD card!")
@@ -110,7 +111,7 @@ def patch_file(origin_file, patch_path, target_file=None):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Copy patch file to temporary directory
         temp_dir = Path(tmpdirname)
-        with importlib.resources.open_binary(__name__, patch_path) as patch_data:
+        with importlib.resources.open_binary(SDCARD_ANCHOR, patch_path) as patch_data:
             patchfile = temp_dir / "patch.patch"
             patchfile.write_bytes(patch_data.read())
 

--- a/worlds/ssbb_sse/docs/en_SubspaceEmissary_Setup.md
+++ b/worlds/ssbb_sse/docs/en_SubspaceEmissary_Setup.md
@@ -39,6 +39,8 @@ The mod for the Subspace Emissary APWorld uses the same loading method as most B
 
     ![](images/dolphintool.png)
 
+    **Note:** The Linux Distribution of Dolphin does **not** include DolphinTool, and as such, it must be installed separately. Install `dolphin-emu-tool`, then use `whereis dolphin-tool` to find the install location. Select this location instead of `DolphinTool.exe`
+
     It will also ask you for your Super Smash Bros. Brawl ROM. Note that **only NTSC USA ROMs** will work, and other releases will be rejected. (However, both v1.01 and v1.02 are usable.)
 
     **Note:** At the moment, this APWorld does not support customization, so you can use the same SD card for every run. This means you **do not** have to run `/create_sd` if you've already done it before.


### PR DESCRIPTION
Fixes the usage of importlib to access data in a subdirectory in the intended way. At least for me on Linux, this was a necessary change, as the previous code generated an error

I also wanted to document the differences in how DolphinTool is distributed on Linux and Windows to help clarify what the setup process should entail on Linux